### PR TITLE
Changed image rule from 'width' to 'max-width' rule

### DIFF
--- a/starter-code/styles/base.css
+++ b/starter-code/styles/base.css
@@ -4,10 +4,10 @@ body {
   color: #313131;
 }
 
-/* TODO: Add a rule for images, so they never exceed their container's width. */
+/* TODO: DONE Add a rule for images, so they never exceed their container's width. */
 
 img {
-  width: 100%;
+  max-width: 100%;
 }
 
 hr {

--- a/starter-code/styles/modules.css
+++ b/starter-code/styles/modules.css
@@ -8,7 +8,7 @@
   padding: 0 0 .2em 1em;
 }
 
-/* TODO: Add styles for the icon-menu class. It should be bigger, and off to the right. */
+/* TODO: DONE Add styles for the icon-menu class. It should be bigger, and off to the right. */
 .icon-menu {
   font-size: 2em;
   display: block;
@@ -80,4 +80,3 @@
     padding-left: 30%;
   }
 }
-


### PR DESCRIPTION
#### Single-line Summary
**Today, David and Daniel paired together. It took about  2 hours to complete.**

#### Reflect and summarize on your process for each `TODO` item :  
  1. First, we added a meta tag for the viewport on index.html.
  2. Next, we added the menu icon as an <i> element in index.html.
  3. Then we opened base.css and added a rule for <img> to be 100% of the parent container.
  4. After that we, added a rule for our new menu icon to increase the size and float it to the right side of the screen in modules.css
  5. Finally, we added a media query at the bottom of module.css that applies when the screen size is above 800px. It displays all the menu links in a straight line and hides the original icon.
  **6. RESUBMISSION: I went through and merged our branches together so that they reflect commits made from both Dan and I. I also changed the image 'width' rule to a 'max-width' rule so it will limit the size of the image instead of setting it.**

#### Checklist (before submitting, fill in each set of square brackets with an 'x')
- [x] I have entered the Pull Request title in the format of "firstname-lastname"
- [x] This PR includes commits from both myself and my partner; e.g. We followed good pair programming practices by switching driver/navigator roles.
**NOTE: we both made our commits regularly but there was some confusion initially about how many branches we actually needed to make. Some commits are done on separate branches.
These commits can be seen  [HERE](https://github.com/squeekyfoot/01-mobile-first/branches)**
- [x] There is no extraneous, unrelated code included in this PR.
- [x] We have summarized our `TODO:` process above.